### PR TITLE
updated the version numbers for the Temporal SDK and all project depe…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'java'
 sourceSets.main.java.srcDirs 'src'
 
 dependencies {
-    implementation 'io.temporal:temporal-sdk:1.22.2'
-    implementation 'org.slf4j:slf4j-nop:2.0.6' // logging suppression
-    implementation 'commons-io:commons-io:2.11.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
-    implementation 'org.json:json:20210307'
+    implementation 'io.temporal:temporal-sdk:1.31.0'
+    implementation 'org.slf4j:slf4j-nop:2.0.17' // logging suppression
+    implementation 'commons-io:commons-io:2.20.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.2.0'
+    implementation 'org.json:json:20250517'
 }
 
 // Run the App


### PR DESCRIPTION
## What was changed?

I updated the version numbers for the Temporal SDK and all project dependencies (junit, slf4j, commons-lang, etc.) to the latest stable versions.

## Why?

The Temporal SDK referenced in this tutorial was several versions behind what's current, as were other libraries it uses. I updated them to what is now the latest stable release. This eliminates security vulnerabilities in older versions of project dependencies (such as JUnit or Apache Commons Lang) and also conveys to our learners that our tutorials are maintained and worth their time to complete.

I tested this by running `gradle compileJava compileTestJava test` on a clean checkout to ensure that the code compiled with the new versions and that all automated tests were successful. 

Note that this PR updates the code, but the prose for the tutorial is in a different repo and I've [submitted a PR](https://github.com/temporalio/temporal-learning/pull/424) there to handle that. Both PRs should be merged with minimal delay between them as possible.